### PR TITLE
Added the Gitlab AWS Submodule to the repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "aws"]
+	path = aws
+	url = http://10.0.30.206/web/thinkbigg-nextjs-aws.git


### PR DESCRIPTION
Previously, the aws dir was added incorrectly as a repo. this PR resolves that by removing the original repo and then adding it back in as a submodule.